### PR TITLE
Fixed removeNode leaving references in outgoingEdges and reference to…

### DIFF
--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -50,12 +50,14 @@ DepGraph.prototype = {
     delete this.nodes[name];
     delete this.outgoingEdges[name];
     delete this.incomingEdges[name];
-    Object.keys(this.incomingEdges).forEach(function (key) {
-      var idx = this.incomingEdges[key].indexOf(name);
-      if (idx >= 0) {
-        edges.splice(idx, 1);
-      }
-    }, this);
+    [this.incomingEdges, this.outgoingEdges].forEach(function (edgeList) {
+      Object.keys(edgeList).forEach(function (key) {
+        var idx = edgeList[key].indexOf(name);
+        if (idx >= 0) {
+          edgeList[key].splice(idx, 1);
+        }
+      }, this);
+    });
   },
   hasNode:function (name) {
     return !!this.nodes[name];


### PR DESCRIPTION
… non-existent var edges

For example: 

var deps = new (require('dependency-graph').DepGraph)();
deps.addNode('a');
deps.addNode('b');
deps.addNode('c');
deps.addDependency('a', 'b');
deps.addDependency('b', 'c');
console.log(deps);
deps.removeNode('c');
console.log(deps);

{ nodes: { a: 'a', b: 'b', c: 'c' },
  outgoingEdges: { a: [ 'b' ], b: [ 'c' ], c: [] },
  incomingEdges: { a: [], b: [ 'a' ], c: [ 'b' ] } }
{ nodes: { a: 'a', b: 'b' },
  outgoingEdges: { a: [ 'b' ], b: [ 'c' ] },
  incomingEdges: { a: [], b: [ 'a' ] } }
