### PR TITLE
Check all nodes for potential cycles when calculating overall order. Fixes #8

### DIFF
--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -118,6 +118,9 @@ DepGraph.prototype = {
   },
   /**
    * Get an array containing the nodes that the specified node depends on (transitively).
+   *
+   * Throws an Error if the graph has a cycle, or the specified node does not exist.
+   *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned
    * in the array.
    */
@@ -138,6 +141,9 @@ DepGraph.prototype = {
   },
   /**
    * get an array containing the nodes that depend on the specified node (transitively).
+   *
+   * Throws an Error if the graph has a cycle, or the specified node does not exist.
+   *
    * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
    */
   dependantsOf:function (name, leavesOnly) {
@@ -156,27 +162,37 @@ DepGraph.prototype = {
   },
   /**
    * Construct the overall processing order for the dependency graph.
+   *
+   * Throws an Error if the graph has a cycle.
+   *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
    */
   overallOrder:function (leavesOnly) {
     var self = this;
     var result = [];
-    var DFS = createDFS(this.outgoingEdges, leavesOnly, result);
     var keys = Object.keys(this.nodes);
     if (keys.length === 0) {
       return result; // Empty graph
     } else {
+      // Look for cycles - we run the DFS starting at all the nodes in case there
+      // are several disconnected subgraphs inside this dependency graph.
+      var CycleDFS = createDFS(this.outgoingEdges, false, []);
+      keys.forEach(function(n) {
+        CycleDFS(n);
+      });
+
+      var DFS = createDFS(this.outgoingEdges, leavesOnly, result);
+      // Find all potential starting points (nodes with nothing depending on them) an
+      // run a DFS starting at these points to get the order
       keys.filter(function (node) {
         return self.incomingEdges[node].length === 0;
       }).forEach(function (n) {
         DFS(n);
       });
-      if (result.length === 0) {
-        // There's definitely a cycle somewhere - run the DFS on the first node
-        // so that it constructs the cycle and reports it.
-        DFS(keys[0]);
-      }
+
       return result;
     }
-  }
+  },
+
+
 };

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -99,7 +99,7 @@ describe('DepGraph', function () {
 
     expect(function () {
       graph.overallOrder();
-    }).toThrow(new Error('Dependency Cycle Found: d -> a -> b -> c -> a'));
+    }).toThrow(new Error('Dependency Cycle Found: a -> b -> c -> a'));
   });
 
   it('should detect cycles in overall order when all nodes have dependants (incoming edges)', function () {
@@ -116,6 +116,26 @@ describe('DepGraph', function () {
     expect(function () {
       graph.overallOrder();
     }).toThrow(new Error('Dependency Cycle Found: a -> b -> c -> a'));
+  });
+
+  it('should detect cycles in overall order when there are several ' +
+     'disconnected subgraphs (with one that does not have a cycle', function () {
+    var graph = new DepGraph();
+
+    graph.addNode('a_1');
+    graph.addNode('a_2');
+    graph.addNode('b_1');
+    graph.addNode('b_2');
+    graph.addNode('b_3');
+
+    graph.addDependency('a_1', 'a_2');
+    graph.addDependency('b_1', 'b_2');
+    graph.addDependency('b_2', 'b_3');
+    graph.addDependency('b_3', 'b_1');
+
+    expect(function () {
+      graph.overallOrder();
+    }).toThrow(new Error('Dependency Cycle Found: b_1 -> b_2 -> b_3 -> b_1'));
   });
 
   it('should retrieve dependencies and dependants in the correct order', function () {
@@ -174,6 +194,22 @@ describe('DepGraph', function () {
     graph.addDependency('c', 'd');
 
     expect(graph.overallOrder(true)).toEqual(['d', 'e']);
+  });
+
+  it('should be able to give the overall order for a graph with several disconnected subgraphs', function () {
+    var graph = new DepGraph();
+
+    graph.addNode('a_1');
+    graph.addNode('a_2');
+    graph.addNode('b_1');
+    graph.addNode('b_2');
+    graph.addNode('b_3');
+
+    graph.addDependency('a_1', 'a_2');
+    graph.addDependency('b_1', 'b_2');
+    graph.addDependency('b_2', 'b_3');
+
+    expect(graph.overallOrder()).toEqual(['a_2', 'a_1', 'b_3', 'b_2', 'b_1']);
   });
 
   it('should give an empty overall order for an empty graph', function () {


### PR DESCRIPTION
Some new tests as well that check that:

- Cycle is found when there are several disconnected subgraphs in the graph where one of the subgraphs has a cycle.
- Correct overall order is calculated when there are several disconnected subgraphs.