### PR TITLE
Allows for circular dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Nodes in the graph are just simple strings with optional data associated with th
  - `addDependency(from, to)` - add a dependency between two nodes (will throw an Error if one of the nodes does not exist)
  - `removeDependency(from, to)` - remove a dependency between two nodes
  - `clone()` - return a clone of the graph. Any data attached to the nodes will only be *shallow-copied*
- - `dependenciesOf(name, leavesOnly)` - get an array containing the nodes that the specified node depends on (transitively). If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned in the array.
- - `dependantsOf(name, leavesOnly)` - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
- - `overallOrder(leavesOnly)` - construct the overall processing order for the dependency graph. If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
+ - `dependenciesOf(name, leavesOnly, allowCycles)` - get an array containing the nodes that the specified node depends on (transitively). If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned in the array.
+ - `dependantsOf(name, leavesOnly, allowCycles)` - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
+ - `overallOrder(leavesOnly, allowCycles)` - construct the overall processing order for the dependency graph. If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
 
-Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, and `overallOrder` and if one is found, an error will be thrown that includes what the cycle was in the message: e.g. `Dependency Cycle Found: a -> b -> c -> a`.
+Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, and `overallOrder` and if one is found, an error will be thrown that includes what the cycle was in the message: e.g. `Dependency Cycle Found: a -> b -> c -> a`. If you wish to silence this error, pass `true` as the value to `allowCycles` in any of these methods.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Nodes in the graph are just simple strings with optional data associated with th
  - `addDependency(from, to)` - add a dependency between two nodes (will throw an Error if one of the nodes does not exist)
  - `removeDependency(from, to)` - remove a dependency between two nodes
  - `clone()` - return a clone of the graph. Any data attached to the nodes will only be *shallow-copied*
- - `dependenciesOf(name, leavesOnly, allowCycles)` - get an array containing the nodes that the specified node depends on (transitively). If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned in the array.
- - `dependantsOf(name, leavesOnly, allowCycles)` - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
- - `overallOrder(leavesOnly, allowCycles)` - construct the overall processing order for the dependency graph. If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
+ - `dependenciesOf(name, leavesOnly)` - get an array containing the nodes that the specified node depends on (transitively). If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned in the array.
+ - `dependantsOf(name, leavesOnly)` - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
+ - `overallOrder(leavesOnly)` - construct the overall processing order for the dependency graph. If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
 
-Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, and `overallOrder` and if one is found, an error will be thrown that includes what the cycle was in the message: e.g. `Dependency Cycle Found: a -> b -> c -> a`. If you wish to silence this error, pass `true` as the value to `allowCycles` in any of these methods.
+Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, and `overallOrder` and if one is found, an error will be thrown that includes what the cycle was in the message: e.g. `Dependency Cycle Found: a -> b -> c -> a`. If you wish to silence this error, pass `circular: true` when instantiating `DepGraph` (more below).
 
 ## Examples
 
@@ -57,3 +57,18 @@ Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, an
     graph.setNodeData('d', 'newData');
 
     graph.getNodeData('d'); // 'newData'
+
+    var circularGraph = new DepGraph({ circular: true });
+
+    circularGraph.addNode('a');
+    circularGraph.addNode('b');
+    circularGraph.addNode('c');
+    circularGraph.addNode('d');
+
+    circularGraph.addDependency('a', 'b');
+    circularGraph.addDependency('b', 'c'); // b depends on c
+    circularGraph.addDependency('c', 'a'); // c depends on a, which depends on b
+    circularGraph.addDependency('d', 'a');
+
+    circularGraph.dependenciesOf('b'); // ['a', 'c']
+    circularGraph.overallOrder(); // ['c', 'b', 'a', 'd']

--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -11,8 +11,9 @@
  * @param edges The set of edges to DFS through
  * @param leavesOnly Whether to only return "leaf" nodes (ones who have no edges)
  * @param result An array in which the results will be populated
+ * @param allowCycles A boolean to allow circular dependencies
  */
-function createDFS(edges, leavesOnly, result) {
+function createDFS(edges, leavesOnly, result, allowCycles) {
   var currentPath = [];
   var visited = {};
   return function DFS(currentNode) {
@@ -23,7 +24,9 @@ function createDFS(edges, leavesOnly, result) {
         DFS(node);
       } else if (currentPath.indexOf(node) >= 0) {
         currentPath.push(node);
-        throw new Error('Dependency Cycle Found: ' + currentPath.join(' -> '));
+        if (!allowCycles) {
+          throw new Error('Dependency Cycle Found: ' + currentPath.join(' -> '));
+        }
       }
     });
     currentPath.pop();
@@ -168,10 +171,10 @@ DepGraph.prototype = {
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned
    * in the array.
    */
-  dependenciesOf:function (node, leavesOnly) {
+  dependenciesOf:function (node, leavesOnly, allowCycles) {
     if (this.hasNode(node)) {
       var result = [];
-      var DFS = createDFS(this.outgoingEdges, leavesOnly, result);
+      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, allowCycles);
       DFS(node);
       var idx = result.indexOf(node);
       if (idx >= 0) {
@@ -190,10 +193,10 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
    */
-  dependantsOf:function (node, leavesOnly) {
+  dependantsOf:function (node, leavesOnly, allowCycles) {
     if (this.hasNode(node)) {
       var result = [];
-      var DFS = createDFS(this.incomingEdges, leavesOnly, result);
+      var DFS = createDFS(this.incomingEdges, leavesOnly, result, allowCycles);
       DFS(node);
       var idx = result.indexOf(node);
       if (idx >= 0) {
@@ -211,7 +214,7 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
    */
-  overallOrder:function (leavesOnly) {
+  overallOrder:function (leavesOnly, allowCycles) {
     var self = this;
     var result = [];
     var keys = Object.keys(this.nodes);
@@ -220,12 +223,12 @@ DepGraph.prototype = {
     } else {
       // Look for cycles - we run the DFS starting at all the nodes in case there
       // are several disconnected subgraphs inside this dependency graph.
-      var CycleDFS = createDFS(this.outgoingEdges, false, []);
+      var CycleDFS = createDFS(this.outgoingEdges, false, [], allowCycles);
       keys.forEach(function(n) {
         CycleDFS(n);
       });
 
-      var DFS = createDFS(this.outgoingEdges, leavesOnly, result);
+      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, allowCycles);
       // Find all potential starting points (nodes with nothing depending on them) an
       // run a DFS starting at these points to get the order
       keys.filter(function (node) {

--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -11,9 +11,9 @@
  * @param edges The set of edges to DFS through
  * @param leavesOnly Whether to only return "leaf" nodes (ones who have no edges)
  * @param result An array in which the results will be populated
- * @param allowCycles A boolean to allow circular dependencies
+ * @param circular A boolean to allow circular dependencies
  */
-function createDFS(edges, leavesOnly, result, allowCycles) {
+function createDFS(edges, leavesOnly, result, circular) {
   var currentPath = [];
   var visited = {};
   return function DFS(currentNode) {
@@ -24,7 +24,7 @@ function createDFS(edges, leavesOnly, result, allowCycles) {
         DFS(node);
       } else if (currentPath.indexOf(node) >= 0) {
         currentPath.push(node);
-        if (!allowCycles) {
+        if (!circular) {
           throw new Error('Dependency Cycle Found: ' + currentPath.join(' -> '));
         }
       }
@@ -39,10 +39,11 @@ function createDFS(edges, leavesOnly, result, allowCycles) {
 /**
  * Simple Dependency Graph
  */
-var DepGraph = exports.DepGraph = function DepGraph() {
+var DepGraph = exports.DepGraph = function DepGraph(opts) {
   this.nodes = {}; // Node -> Node/Data (treated like a Set)
   this.outgoingEdges = {}; // Node -> [Dependency Node]
   this.incomingEdges = {}; // Node -> [Dependant Node]
+  this.circular = opts && !!opts.circular; // Allows circular deps
 };
 DepGraph.prototype = {
   /**
@@ -171,10 +172,10 @@ DepGraph.prototype = {
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned
    * in the array.
    */
-  dependenciesOf:function (node, leavesOnly, allowCycles) {
+  dependenciesOf:function (node, leavesOnly) {
     if (this.hasNode(node)) {
       var result = [];
-      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, allowCycles);
+      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, this.circular);
       DFS(node);
       var idx = result.indexOf(node);
       if (idx >= 0) {
@@ -193,10 +194,10 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
    */
-  dependantsOf:function (node, leavesOnly, allowCycles) {
+  dependantsOf:function (node, leavesOnly) {
     if (this.hasNode(node)) {
       var result = [];
-      var DFS = createDFS(this.incomingEdges, leavesOnly, result, allowCycles);
+      var DFS = createDFS(this.incomingEdges, leavesOnly, result, this.circular);
       DFS(node);
       var idx = result.indexOf(node);
       if (idx >= 0) {
@@ -214,7 +215,7 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
    */
-  overallOrder:function (leavesOnly, allowCycles) {
+  overallOrder:function (leavesOnly) {
     var self = this;
     var result = [];
     var keys = Object.keys(this.nodes);
@@ -223,12 +224,12 @@ DepGraph.prototype = {
     } else {
       // Look for cycles - we run the DFS starting at all the nodes in case there
       // are several disconnected subgraphs inside this dependency graph.
-      var CycleDFS = createDFS(this.outgoingEdges, false, [], allowCycles);
+      var CycleDFS = createDFS(this.outgoingEdges, false, [], this.circular);
       keys.forEach(function(n) {
         CycleDFS(n);
       });
 
-      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, allowCycles);
+      var DFS = createDFS(this.outgoingEdges, leavesOnly, result, this.circular);
       // Find all potential starting points (nodes with nothing depending on them) an
       // run a DFS starting at these points to get the order
       keys.filter(function (node) {

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -164,7 +164,7 @@ describe('DepGraph', function () {
     }).toThrow(new Error('Dependency Cycle Found: b -> c -> a -> b'));
   });
 
-  it('should detect cycles', function () {
+  it('should allow cycles when configured', function () {
     var graph = new DepGraph({ circular: true });
 
     graph.addNode('a');

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -164,6 +164,23 @@ describe('DepGraph', function () {
     }).toThrow(new Error('Dependency Cycle Found: b -> c -> a -> b'));
   });
 
+  it('should detect cycles', function () {
+    var graph = new DepGraph({ circular: true });
+
+    graph.addNode('a');
+    graph.addNode('b');
+    graph.addNode('c');
+    graph.addNode('d');
+
+    graph.addDependency('a', 'b');
+    graph.addDependency('b', 'c');
+    graph.addDependency('c', 'a');
+    graph.addDependency('d', 'a');
+
+    expect(graph.dependenciesOf('b')).toEqual(['a', 'c']);
+    expect(graph.overallOrder()).toEqual(['c', 'b', 'a', 'd']);
+  });
+
   it('should detect cycles in overall order', function () {
     var graph = new DepGraph();
 


### PR DESCRIPTION
When working with ES Module dependencies, this graph is very handy. I'd
like to expand it to support circular dependencies, which aren't an
issue in this realm.

I don't think this API is the most ideal, since it tacks on yet another
argument to all the calls. I didn't add tests yet, since I wanted to
gauge your opinion.