### PR TITLE
Document constructor in TypeScript typings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,14 @@
 declare module 'dependency-graph' {
+  export interface Options {
+    circular?: boolean;
+  }
+
   export class DepGraph<T> {
+    /**
+     * Creates an instance of DepGraph with optional Options.
+     */
+    constructor(opts: Options): DepGraph;
+
     /**
      * The number of nodes in the graph.
      */


### PR DESCRIPTION
When I introduced the circular option, I neglected to update the typings file as I was not using TypeScript at the time. Now I am refactoring my bundler to use TypeScript and this error popped up. Correcting it now.