### PR TITLE
Fixes typo for consistency: dependants → dependents.

### DIFF
--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -42,8 +42,9 @@ function createDFS(edges, leavesOnly, result, circular) {
 var DepGraph = exports.DepGraph = function DepGraph(opts) {
   this.nodes = {}; // Node -> Node/Data (treated like a Set)
   this.outgoingEdges = {}; // Node -> [Dependency Node]
-  this.incomingEdges = {}; // Node -> [Dependant Node]
+  this.incomingEdges = {}; // Node -> [Dependent Node]
   this.circular = opts && !!opts.circular; // Allows circular deps
+  this.dependantsOf = this.dependentsOf; // alias typo'd method for API compat
 };
 DepGraph.prototype = {
   /**
@@ -192,9 +193,9 @@ DepGraph.prototype = {
    *
    * Throws an Error if the graph has a cycle, or the specified node does not exist.
    *
-   * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
+   * If `leavesOnly` is true, only nodes that do not have any dependents will be returned in the array.
    */
-  dependantsOf:function (node, leavesOnly) {
+  dependentsOf:function (node, leavesOnly) {
     if (this.hasNode(node)) {
       var result = [];
       var DFS = createDFS(this.incomingEdges, leavesOnly, result, this.circular);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -74,9 +74,16 @@ declare module 'dependency-graph' {
     dependenciesOf(name: string, leavesOnly?: boolean): string[];
 
     /**
-     * Get an array containing the nodes that depend on the specified node (transitively). If leavesOnly is true, only nodes that do not have any dependants will be returned in the array.
+     * Get an array containing the nodes that depend on the specified node (transitively). If leavesOnly is true, only nodes that do not have any dependents will be returned in the array.
      * @param {string} name
      * @param {boolean} leavesOnly
+     */
+    dependentsOf(name: string, leavesOnly?: boolean): string[];
+
+    /**
+     * Alias of DepGraph.dependentsOf.
+     * @param {string} name 
+     * @param {boolean} leavesOnly 
      */
     dependantsOf(name: string, leavesOnly?: boolean): string[];
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dependency-graph",
   "description": "Simple dependency graph.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "author": "Jim Riecken <jriecken@gmail.com>",
   "keywords": [
     "dependency",


### PR DESCRIPTION
Howdy! Thanks much for your work.

Offering a PR with a minor typo fix, as I've been bit by this one a couple times and I reckon some other Americans have too.

"Dependant" (in the `dependantsOf` method) is a valid (albeit archaic) spelling, so ordinarily I wouldn't nitpick -- but as dependency-with-an-e is used throughout the rest of the codebase, I figure it might make sense to offer the consistent, US spelling as an alias of the other.

Feel free to ignore entirely. It's really a minor thing, but I figure it might help somebody out somewhere. Cheers.