### PR TITLE
Add a DepGraphCycleError with cyclePath property

### DIFF
--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -25,7 +25,7 @@ function createDFS(edges, leavesOnly, result, circular) {
       } else if (currentPath.indexOf(node) >= 0) {
         currentPath.push(node);
         if (!circular) {
-          throw new Error('Dependency Cycle Found: ' + currentPath.join(' -> '));
+          throw new DepGraphCycleError(currentPath);
         }
       }
     });
@@ -242,3 +242,26 @@ DepGraph.prototype = {
     }
   }
 };
+
+/**
+ * Cycle error, including the path of the cycle.
+ */
+var DepGraphCycleError = exports.DepGraphCycleError = function (cyclePath) {
+  var message = 'Dependency Cycle Found: ' + cyclePath.join(' -> ')
+  var instance = new Error(message);
+  instance.cyclePath = cyclePath;
+  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(instance, DepGraphCycleError);
+  }
+  return instance;
+}
+DepGraphCycleError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+Object.setPrototypeOf(DepGraphCycleError, Error);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -86,4 +86,8 @@ declare module 'dependency-graph' {
      */
     overallOrder(leavesOnly?: boolean): string[];
   }
+
+  export class DepGraphCycleError extends Error {
+    cyclePath: string[];
+  }
 }

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -1,4 +1,5 @@
-var DepGraph = require('../lib/dep_graph').DepGraph;
+var dep_graph = require('../lib/dep_graph');
+var DepGraph = dep_graph.DepGraph;
 
 describe('DepGraph', function () {
 
@@ -161,7 +162,7 @@ describe('DepGraph', function () {
 
     expect(function () {
       graph.dependenciesOf('b');
-    }).toThrow(new Error('Dependency Cycle Found: b -> c -> a -> b'));
+    }).toThrow(new dep_graph.DepGraphCycleError(['b', 'c', 'a', 'b']));
   });
 
   it('should allow cycles when configured', function () {
@@ -196,7 +197,7 @@ describe('DepGraph', function () {
 
     expect(function () {
       graph.overallOrder();
-    }).toThrow(new Error('Dependency Cycle Found: a -> b -> c -> a'));
+    }).toThrow(new dep_graph.DepGraphCycleError(['a', 'b', 'c', 'a']));
   });
 
   it('should detect cycles in overall order when all nodes have dependants (incoming edges)', function () {
@@ -212,7 +213,7 @@ describe('DepGraph', function () {
 
     expect(function () {
       graph.overallOrder();
-    }).toThrow(new Error('Dependency Cycle Found: a -> b -> c -> a'));
+    }).toThrow(new dep_graph.DepGraphCycleError(['a', 'b', 'c', 'a']));
   });
 
   it('should detect cycles in overall order when there are several ' +
@@ -232,7 +233,7 @@ describe('DepGraph', function () {
 
     expect(function () {
       graph.overallOrder();
-    }).toThrow(new Error('Dependency Cycle Found: b_1 -> b_2 -> b_3 -> b_1'));
+    }).toThrow(new dep_graph.DepGraphCycleError(['b_1', 'b_2', 'b_3', 'b_1']));
   });
 
   it('should retrieve dependencies and dependants in the correct order', function () {
@@ -385,5 +386,26 @@ describe('DepGraph', function () {
     cloned.setNodeData('a', {a: 42});
     expect(cloned.getNodeData('a').a).toEqual(42);
     expect(graph.getNodeData('a') === cloned.getNodeData('a')).toBe(false);
+  });
+});
+
+describe('DepGraphCycleError', function() {
+  var DepGraphCycleError = dep_graph.DepGraphCycleError;
+  
+  it('should have a message', function() {
+    var err = new DepGraphCycleError(['a', 'b', 'c', 'a']);
+    expect(err.message).toEqual('Dependency Cycle Found: a -> b -> c -> a');
+  });
+
+  it('should be an instanceof DepGraphCycleError', function() {
+    var err = new DepGraphCycleError(['a', 'b', 'c', 'a']);
+    expect(err instanceof DepGraphCycleError).toBe(true);
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('should have a cyclePath', function() {
+    var cyclePath = ['a', 'b', 'c', 'a'];
+    var err = new DepGraphCycleError(cyclePath);
+    expect(err.cyclePath).toEqual(cyclePath);
   });
 });


### PR DESCRIPTION
Fixes #29.

This PR adds a custom `DepGraphCycleError`, with a `cyclePath` property, giving the path names of the nodes in the cycle. The does not entirely satisfy #23, as there exists an error thrown for `No such node`.

It adds tests and type info for the error message.

The error declaration targets ES5.