### PR TITLE
Add methods for retrieving direct dependency information. Fixes #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Nodes in the graph are just simple strings with optional data associated with th
  - `removeDependency(from, to)` - remove a dependency between two nodes
  - `clone()` - return a clone of the graph. Any data attached to the nodes will only be *shallow-copied*
  - `dependenciesOf(name, leavesOnly)` - get an array containing the nodes that the specified node depends on (transitively). If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned in the array.
- - `dependantsOf(name, leavesOnly)` - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
+ - `dependantsOf(name, leavesOnly)` (aliased as `dependentsOf`) - get an array containing the nodes that depend on the specified node (transitively). If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
+ - `directDependenciesOf(name)` - get an array containing the direct dependencies of the specified node
+ - `directDependantsOf(name)` (aliased as `directDependentsOf`) - get an array containing the nodes that directly depend on the specified node
  - `overallOrder(leavesOnly)` - construct the overall processing order for the dependency graph. If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
 
 Dependency Cycles are detected when running `dependenciesOf`, `dependantsOf`, and `overallOrder` and if one is found, a `DepGraphCycleError` will be thrown that includes what the cycle was in the message as well as the `cyclePath` property: e.g. `Dependency Cycle Found: a -> b -> c -> a`. If you wish to silence this error, pass `circular: true` when instantiating `DepGraph` (more below).

--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -15,7 +15,7 @@
  */
 function createDFS(edges, leavesOnly, result, circular) {
   var visited = {};
-  return function(start) {
+  return function (start) {
     if (visited[start]) {
       return;
     }
@@ -78,13 +78,13 @@ DepGraph.prototype = {
   /**
    * The number of nodes in the graph.
    */
-  size: function() {
+  size: function () {
     return Object.keys(this.nodes).length;
   },
   /**
    * Add a node to the dependency graph. If a node already exists, this method will do nothing.
    */
-  addNode: function(node, data) {
+  addNode: function (node, data) {
     if (!this.hasNode(node)) {
       // Checking the arguments length allows the user to add a node with undefined data
       if (arguments.length === 2) {
@@ -99,13 +99,13 @@ DepGraph.prototype = {
   /**
    * Remove a node from the dependency graph. If a node does not exist, this method will do nothing.
    */
-  removeNode: function(node) {
+  removeNode: function (node) {
     if (this.hasNode(node)) {
       delete this.nodes[node];
       delete this.outgoingEdges[node];
       delete this.incomingEdges[node];
-      [this.incomingEdges, this.outgoingEdges].forEach(function(edgeList) {
-        Object.keys(edgeList).forEach(function(key) {
+      [this.incomingEdges, this.outgoingEdges].forEach(function (edgeList) {
+        Object.keys(edgeList).forEach(function (key) {
           var idx = edgeList[key].indexOf(node);
           if (idx >= 0) {
             edgeList[key].splice(idx, 1);
@@ -117,13 +117,13 @@ DepGraph.prototype = {
   /**
    * Check if a node exists in the graph
    */
-  hasNode: function(node) {
+  hasNode: function (node) {
     return this.nodes.hasOwnProperty(node);
   },
   /**
    * Get the data associated with a node name
    */
-  getNodeData: function(node) {
+  getNodeData: function (node) {
     if (this.hasNode(node)) {
       return this.nodes[node];
     } else {
@@ -133,7 +133,7 @@ DepGraph.prototype = {
   /**
    * Set the associated data for a given node name. If the node does not exist, this method will throw an error
    */
-  setNodeData: function(node, data) {
+  setNodeData: function (node, data) {
     if (this.hasNode(node)) {
       this.nodes[node] = data;
     } else {
@@ -144,7 +144,7 @@ DepGraph.prototype = {
    * Add a dependency between two nodes. If either of the nodes does not exist,
    * an Error will be thrown.
    */
-  addDependency: function(from, to) {
+  addDependency: function (from, to) {
     if (!this.hasNode(from)) {
       throw new Error("Node does not exist: " + from);
     }
@@ -162,7 +162,7 @@ DepGraph.prototype = {
   /**
    * Remove a dependency between two nodes.
    */
-  removeDependency: function(from, to) {
+  removeDependency: function (from, to) {
     var idx;
     if (this.hasNode(from)) {
       idx = this.outgoingEdges[from].indexOf(to);
@@ -182,16 +182,40 @@ DepGraph.prototype = {
    * Return a clone of the dependency graph. If any custom data is attached
    * to the nodes, it will only be shallow copied.
    */
-  clone: function() {
+  clone: function () {
     var source = this;
     var result = new DepGraph();
     var keys = Object.keys(source.nodes);
-    keys.forEach(function(n) {
+    keys.forEach(function (n) {
       result.nodes[n] = source.nodes[n];
       result.outgoingEdges[n] = source.outgoingEdges[n].slice(0);
       result.incomingEdges[n] = source.incomingEdges[n].slice(0);
     });
     return result;
+  },
+  /**
+   * Get an array containing the direct dependencies of the specified node.
+   *
+   * Throws an Error if the specified node does not exist.
+   */
+  directDependenciesOf: function (node) {
+    if (this.hasNode(node)) {
+      return this.outgoingEdges[node].slice(0);
+    } else {
+      throw new Error("Node does not exist: " + node);
+    }
+  },
+  /**
+   * Get an array containing the nodes that directly depend on the specified node.
+   *
+   * Throws an Error if the specified node does not exist.
+   */
+  directDependantsOf: function (node) {
+    if (this.hasNode(node)) {
+      return this.incomingEdges[node].slice(0);
+    } else {
+      throw new Error("Node does not exist: " + node);
+    }
   },
   /**
    * Get an array containing the nodes that the specified node depends on (transitively).
@@ -201,7 +225,7 @@ DepGraph.prototype = {
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned
    * in the array.
    */
-  dependenciesOf: function(node, leavesOnly) {
+  dependenciesOf: function (node, leavesOnly) {
     if (this.hasNode(node)) {
       var result = [];
       var DFS = createDFS(
@@ -227,7 +251,7 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not have any dependants will be returned in the array.
    */
-  dependantsOf: function(node, leavesOnly) {
+  dependantsOf: function (node, leavesOnly) {
     if (this.hasNode(node)) {
       var result = [];
       var DFS = createDFS(
@@ -253,7 +277,7 @@ DepGraph.prototype = {
    *
    * If `leavesOnly` is true, only nodes that do not depend on any other nodes will be returned.
    */
-  overallOrder: function(leavesOnly) {
+  overallOrder: function (leavesOnly) {
     var self = this;
     var result = [];
     var keys = Object.keys(this.nodes);
@@ -264,7 +288,7 @@ DepGraph.prototype = {
         // Look for cycles - we run the DFS starting at all the nodes in case there
         // are several disconnected subgraphs inside this dependency graph.
         var CycleDFS = createDFS(this.outgoingEdges, false, [], this.circular);
-        keys.forEach(function(n) {
+        keys.forEach(function (n) {
           CycleDFS(n);
         });
       }
@@ -278,10 +302,10 @@ DepGraph.prototype = {
       // Find all potential starting points (nodes with nothing depending on them) an
       // run a DFS starting at these points to get the order
       keys
-        .filter(function(node) {
+        .filter(function (node) {
           return self.incomingEdges[node].length === 0;
         })
-        .forEach(function(n) {
+        .forEach(function (n) {
           DFS(n);
         });
 
@@ -290,10 +314,10 @@ DepGraph.prototype = {
       // subgraph that does not have a clear starting point)
       if (this.circular) {
         keys
-          .filter(function(node) {
+          .filter(function (node) {
             return result.indexOf(node) === -1;
           })
-          .forEach(function(n) {
+          .forEach(function (n) {
             DFS(n);
           });
       }
@@ -303,10 +327,14 @@ DepGraph.prototype = {
   }
 };
 
+// Create some aliases
+DepGraph.prototype.directDependentsOf = DepGraph.prototype.directDependantsOf;
+DepGraph.prototype.dependentsOf = DepGraph.prototype.dependantsOf;
+
 /**
  * Cycle error, including the path of the cycle.
  */
-var DepGraphCycleError = (exports.DepGraphCycleError = function(cyclePath) {
+var DepGraphCycleError = (exports.DepGraphCycleError = function (cyclePath) {
   var message = "Dependency Cycle Found: " + cyclePath.join(" -> ");
   var instance = new Error(message);
   instance.cyclePath = cyclePath;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -67,6 +67,26 @@ declare module 'dependency-graph' {
     clone(): DepGraph<T>;
 
     /**
+     * Get an array containing the direct dependency nodes of the specified node.
+     * @param name
+     */
+    directDependenciesOf(name: string): string[];
+
+    /**
+     * Get an array containing the nodes that directly depend on the specified node.
+     * @param name
+     */
+    directDependantsOf(name: string): string[];
+
+    /**
+     * Alias of `directDependantsOf`
+     *
+     * @see directDependantsOf
+     * @param {string} name
+     */
+    directDependentsOf(name: string): string[];
+
+    /**
      * Get an array containing the nodes that the specified node depends on (transitively). If leavesOnly is true, only nodes that do not depend on any other nodes will be returned in the array.
      * @param {string} name
      * @param {boolean} leavesOnly
@@ -79,6 +99,15 @@ declare module 'dependency-graph' {
      * @param {boolean} leavesOnly
      */
     dependantsOf(name: string, leavesOnly?: boolean): string[];
+
+    /**
+     * Alias of `dependentsOf`
+     *
+     * @see dependantsOf
+     * @param name
+     * @param leavesOnly
+     */
+    dependentsOf(name: string, leavesOnly?: boolean): string[];
 
     /**
      * Construct the overall processing order for the dependency graph. If leavesOnly is true, only nodes that do not depend on any other nodes will be returned.

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -1,8 +1,8 @@
 var dep_graph = require("../lib/dep_graph");
 var DepGraph = dep_graph.DepGraph;
 
-describe("DepGraph", function() {
-  it("should be able to add/remove nodes", function() {
+describe("DepGraph", function () {
+  it("should be able to add/remove nodes", function () {
     var graph = new DepGraph();
 
     graph.addNode("Foo");
@@ -17,7 +17,7 @@ describe("DepGraph", function() {
     expect(graph.hasNode("Bar")).toBeFalse();
   });
 
-  it("should calculate its size", function() {
+  it("should calculate its size", function () {
     var graph = new DepGraph();
 
     expect(graph.size()).toBe(0);
@@ -32,7 +32,7 @@ describe("DepGraph", function() {
     expect(graph.size()).toBe(1);
   });
 
-  it("should treat the node data parameter as optional and use the node name as data if node data was not given", function() {
+  it("should treat the node data parameter as optional and use the node name as data if node data was not given", function () {
     var graph = new DepGraph();
 
     graph.addNode("Foo");
@@ -40,7 +40,7 @@ describe("DepGraph", function() {
     expect(graph.getNodeData("Foo")).toBe("Foo");
   });
 
-  it("should be able to associate a node name with data on node add", function() {
+  it("should be able to associate a node name with data on node add", function () {
     var graph = new DepGraph();
 
     graph.addNode("Foo", "data");
@@ -48,7 +48,7 @@ describe("DepGraph", function() {
     expect(graph.getNodeData("Foo")).toBe("data");
   });
 
-  it("should be able to add undefined as node data", function() {
+  it("should be able to add undefined as node data", function () {
     var graph = new DepGraph();
 
     graph.addNode("Foo", undefined);
@@ -56,13 +56,13 @@ describe("DepGraph", function() {
     expect(graph.getNodeData("Foo")).toBeUndefined();
   });
 
-  it("should return true when using hasNode with a node which has falsy data", function() {
+  it("should return true when using hasNode with a node which has falsy data", function () {
     var graph = new DepGraph();
 
     var falsyData = ["", 0, null, undefined, false];
     graph.addNode("Foo");
 
-    falsyData.forEach(function(data) {
+    falsyData.forEach(function (data) {
       graph.setNodeData("Foo", data);
 
       expect(graph.hasNode("Foo")).toBeTrue();
@@ -72,7 +72,7 @@ describe("DepGraph", function() {
     });
   });
 
-  it("should be able to set data after a node was added", function() {
+  it("should be able to set data after a node was added", function () {
     var graph = new DepGraph();
 
     graph.addNode("Foo", "data");
@@ -81,23 +81,23 @@ describe("DepGraph", function() {
     expect(graph.getNodeData("Foo")).toBe("data2");
   });
 
-  it("should throw an error if we try to set data for a non-existing node", function() {
+  it("should throw an error if we try to set data for a non-existing node", function () {
     var graph = new DepGraph();
 
-    expect(function() {
+    expect(function () {
       graph.setNodeData("Foo", "data");
     }).toThrow(new Error("Node does not exist: Foo"));
   });
 
-  it("should throw an error if the node does not exists and we try to get data", function() {
+  it("should throw an error if the node does not exists and we try to get data", function () {
     var graph = new DepGraph();
 
-    expect(function() {
+    expect(function () {
       graph.getNodeData("Foo");
     }).toThrow(new Error("Node does not exist: Foo"));
   });
 
-  it("should do nothing if creating a node that already exists", function() {
+  it("should do nothing if creating a node that already exists", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -110,7 +110,7 @@ describe("DepGraph", function() {
     expect(graph.dependenciesOf("a")).toEqual(["b"]);
   });
 
-  it("should do nothing if removing a node that does not exist", function() {
+  it("should do nothing if removing a node that does not exist", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -123,7 +123,7 @@ describe("DepGraph", function() {
     expect(graph.hasNode("Foo")).toBeFalse();
   });
 
-  it("should be able to add dependencies between nodes", function() {
+  it("should be able to add dependencies between nodes", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -136,17 +136,17 @@ describe("DepGraph", function() {
     expect(graph.dependenciesOf("a")).toEqual(["b", "c"]);
   });
 
-  it("should throw an error if a node does not exist and a dependency is added", function() {
+  it("should throw an error if a node does not exist and a dependency is added", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
 
-    expect(function() {
+    expect(function () {
       graph.addDependency("a", "b");
     }).toThrow(new Error("Node does not exist: b"));
   });
 
-  it("should detect cycles", function() {
+  it("should detect cycles", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -159,12 +159,12 @@ describe("DepGraph", function() {
     graph.addDependency("c", "a");
     graph.addDependency("d", "a");
 
-    expect(function() {
+    expect(function () {
       graph.dependenciesOf("b");
     }).toThrow(new dep_graph.DepGraphCycleError(["b", "c", "a", "b"]));
   });
 
-  it("should allow cycles when configured", function() {
+  it("should allow cycles when configured", function () {
     var graph = new DepGraph({ circular: true });
 
     graph.addNode("a");
@@ -183,8 +183,8 @@ describe("DepGraph", function() {
 
   it(
     "should include all nodes in overall order even from " +
-      "cycles in disconnected subgraphs when circular is true",
-    function() {
+    "cycles in disconnected subgraphs when circular is true",
+    function () {
       var graph = new DepGraph({ circular: true });
 
       graph.addNode("2a");
@@ -218,7 +218,7 @@ describe("DepGraph", function() {
     }
   );
 
-  it("should detect cycles in overall order", function() {
+  it("should detect cycles in overall order", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -231,12 +231,12 @@ describe("DepGraph", function() {
     graph.addDependency("c", "a");
     graph.addDependency("d", "a");
 
-    expect(function() {
+    expect(function () {
       graph.overallOrder();
     }).toThrow(new dep_graph.DepGraphCycleError(["a", "b", "c", "a"]));
   });
 
-  it("should detect cycles in overall order when all nodes have dependants (incoming edges)", function() {
+  it("should detect cycles in overall order when all nodes have dependants (incoming edges)", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -247,15 +247,15 @@ describe("DepGraph", function() {
     graph.addDependency("b", "c");
     graph.addDependency("c", "a");
 
-    expect(function() {
+    expect(function () {
       graph.overallOrder();
     }).toThrow(new dep_graph.DepGraphCycleError(["a", "b", "c", "a"]));
   });
 
   it(
     "should detect cycles in overall order when there are several " +
-      "disconnected subgraphs (with one that does not have a cycle",
-    function() {
+    "disconnected subgraphs (with one that does not have a cycle",
+    function () {
       var graph = new DepGraph();
 
       graph.addNode("a_1");
@@ -269,7 +269,7 @@ describe("DepGraph", function() {
       graph.addDependency("b_2", "b_3");
       graph.addDependency("b_3", "b_1");
 
-      expect(function() {
+      expect(function () {
         graph.overallOrder();
       }).toThrow(
         new dep_graph.DepGraphCycleError(["b_1", "b_2", "b_3", "b_1"])
@@ -277,7 +277,7 @@ describe("DepGraph", function() {
     }
   );
 
-  it("should retrieve dependencies and dependants in the correct order", function() {
+  it("should retrieve dependencies and dependants in the correct order", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -299,9 +299,45 @@ describe("DepGraph", function() {
     expect(graph.dependantsOf("b")).toEqual(["a", "d"]);
     expect(graph.dependantsOf("c")).toEqual(["a", "d", "b"]);
     expect(graph.dependantsOf("d")).toEqual(["a"]);
+
+    // check the alias "dependentsOf"
+    expect(graph.dependentsOf("a")).toEqual([]);
+    expect(graph.dependentsOf("b")).toEqual(["a", "d"]);
+    expect(graph.dependentsOf("c")).toEqual(["a", "d", "b"]);
+    expect(graph.dependentsOf("d")).toEqual(["a"]);
   });
 
-  it("should be able to resolve the overall order of things", function() {
+  it("should be able to retrieve direct dependencies/dependants", function () {
+    var graph = new DepGraph();
+
+    graph.addNode("a");
+    graph.addNode("b");
+    graph.addNode("c");
+    graph.addNode("d");
+
+    graph.addDependency("a", "d");
+    graph.addDependency("a", "b");
+    graph.addDependency("b", "c");
+    graph.addDependency("d", "b");
+
+    expect(graph.directDependenciesOf("a")).toEqual(["d", "b"]);
+    expect(graph.directDependenciesOf("b")).toEqual(["c"]);
+    expect(graph.directDependenciesOf("c")).toEqual([]);
+    expect(graph.directDependenciesOf("d")).toEqual(["b"]);
+
+    expect(graph.directDependantsOf("a")).toEqual([]);
+    expect(graph.directDependantsOf("b")).toEqual(["a", "d"]);
+    expect(graph.directDependantsOf("c")).toEqual(["b"]);
+    expect(graph.directDependantsOf("d")).toEqual(["a"]);
+
+    // check the alias "directDependentsOf"
+    expect(graph.directDependentsOf("a")).toEqual([]);
+    expect(graph.directDependentsOf("b")).toEqual(["a", "d"]);
+    expect(graph.directDependentsOf("c")).toEqual(["b"]);
+    expect(graph.directDependentsOf("d")).toEqual(["a"]);
+  });
+
+  it("should be able to resolve the overall order of things", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -318,7 +354,7 @@ describe("DepGraph", function() {
     expect(graph.overallOrder()).toEqual(["d", "c", "b", "a", "e"]);
   });
 
-  it('should be able to only retrieve the "leaves" in the overall order', function() {
+  it('should be able to only retrieve the "leaves" in the overall order', function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -335,7 +371,7 @@ describe("DepGraph", function() {
     expect(graph.overallOrder(true)).toEqual(["d", "e"]);
   });
 
-  it("should be able to give the overall order for a graph with several disconnected subgraphs", function() {
+  it("should be able to give the overall order for a graph with several disconnected subgraphs", function () {
     var graph = new DepGraph();
 
     graph.addNode("a_1");
@@ -351,13 +387,13 @@ describe("DepGraph", function() {
     expect(graph.overallOrder()).toEqual(["a_2", "a_1", "b_3", "b_2", "b_1"]);
   });
 
-  it("should give an empty overall order for an empty graph", function() {
+  it("should give an empty overall order for an empty graph", function () {
     var graph = new DepGraph();
 
     expect(graph.overallOrder()).toEqual([]);
   });
 
-  it("should still work after nodes are removed", function() {
+  it("should still work after nodes are removed", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -373,7 +409,7 @@ describe("DepGraph", function() {
     expect(graph.dependenciesOf("a")).toEqual(["b"]);
   });
 
-  it("should clone an empty graph", function() {
+  it("should clone an empty graph", function () {
     var graph = new DepGraph();
     expect(graph.size()).toEqual(0);
     var cloned = graph.clone();
@@ -382,7 +418,7 @@ describe("DepGraph", function() {
     expect(graph === cloned).toBeFalse();
   });
 
-  it("should clone a non-empty graph", function() {
+  it("should clone a non-empty graph", function () {
     var graph = new DepGraph();
 
     graph.addNode("a");
@@ -411,7 +447,7 @@ describe("DepGraph", function() {
     expect(cloned.dependenciesOf("a")).toEqual(["c", "b"]);
   });
 
-  it("should only be a shallow clone", function() {
+  it("should only be a shallow clone", function () {
     var graph = new DepGraph();
 
     var data = { a: 42 };
@@ -430,8 +466,8 @@ describe("DepGraph", function() {
   });
 });
 
-describe("DepGraph Performance", function() {
-  it("should not exceed max call stack with a very deep graph", function() {
+describe("DepGraph Performance", function () {
+  it("should not exceed max call stack with a very deep graph", function () {
     var g = new DepGraph();
     var expected = [];
     for (var i = 0; i < 100000; i++) {
@@ -446,8 +482,8 @@ describe("DepGraph Performance", function() {
     expect(order).toEqual(expected);
   });
 
-  it("should run an a reasonable amount of time for a very large graph", function() {
-    var randInt = function(min, max) {
+  it("should run an a reasonable amount of time for a very large graph", function () {
+    var randInt = function (min, max) {
       return Math.floor(Math.random() * (max - min + 1)) + min;
     };
     var g = new DepGraph();
@@ -471,21 +507,21 @@ describe("DepGraph Performance", function() {
   });
 });
 
-describe("DepGraphCycleError", function() {
+describe("DepGraphCycleError", function () {
   var DepGraphCycleError = dep_graph.DepGraphCycleError;
 
-  it("should have a message", function() {
+  it("should have a message", function () {
     var err = new DepGraphCycleError(["a", "b", "c", "a"]);
     expect(err.message).toEqual("Dependency Cycle Found: a -> b -> c -> a");
   });
 
-  it("should be an instanceof DepGraphCycleError", function() {
+  it("should be an instanceof DepGraphCycleError", function () {
     var err = new DepGraphCycleError(["a", "b", "c", "a"]);
     expect(err instanceof DepGraphCycleError).toBeTrue();
     expect(err instanceof Error).toBeTrue();
   });
 
-  it("should have a cyclePath", function() {
+  it("should have a cyclePath", function () {
     var cyclePath = ["a", "b", "c", "a"];
     var err = new DepGraphCycleError(cyclePath);
     expect(err.cyclePath).toEqual(cyclePath);


### PR DESCRIPTION
- `directDependenciesOf` - returns array of direct dependencies
- `directDependantsOf` - returns array of nodes that depend on specified node
- Also aliased all method names with `dependants` to also have `dependents`