### PR TITLE
Using Sets instead of Arrays for adjacency lists

### DIFF
--- a/lib/dep_graph.js
+++ b/lib/dep_graph.js
@@ -8,7 +8,7 @@
  * Detects cycles and throws an Error if one is detected (unless the "circular"
  * parameter is "true" in which case it ignores them).
  *
- * @param edges The edges to DFS through (this is a Map of node to Array of nodes)
+ * @param edges The edges to DFS through (this is a Map of node to Set of nodes)
  * @param leavesOnly Whether to only return "leaf" nodes (ones who have no edges)
  * @param result An array in which the results will be populated
  * @param circular A boolean to allow circular dependencies
@@ -45,7 +45,7 @@ function createDFS(edges, leavesOnly, result, circular) {
 
         inCurrentPath.add(node);
         currentPath.push(node);
-        var nodeEdges = edges.get(node);
+        var nodeEdges = [...edges.get(node)];
         // (push edges onto the todo stack in reverse order to be order-compatible with the old DFS implementation)
         for (var i = nodeEdges.length - 1; i >= 0; i--) {
           todo.push({ node: nodeEdges[i], processed: false });
@@ -57,7 +57,7 @@ function createDFS(edges, leavesOnly, result, circular) {
         currentPath.pop();
         inCurrentPath.delete(node);
         visited.add(node);
-        if (!leavesOnly || edges.get(node).length === 0) {
+        if (!leavesOnly || edges.get(node).size === 0) {
           result.push(node);
         }
       }
@@ -70,8 +70,8 @@ function createDFS(edges, leavesOnly, result, circular) {
  */
 var DepGraph = (exports.DepGraph = function DepGraph(opts) {
   this.nodes = new Map(); // Node -> Node/Data
-  this.outgoingEdges = new Map(); // Node -> [Dependency Node]
-  this.incomingEdges = new Map(); // Node -> [Dependant Node]
+  this.outgoingEdges = new Map(); // Node -> {Dependency Node}
+  this.incomingEdges = new Map(); // Node -> {Dependant Node}
   this.circular = opts && !!opts.circular; // Allows circular deps
 });
 DepGraph.prototype = {
@@ -92,8 +92,8 @@ DepGraph.prototype = {
       } else {
         this.nodes.set(node, node);
       }
-      this.outgoingEdges.set(node, []);
-      this.incomingEdges.set(node, []);
+      this.outgoingEdges.set(node, new Set());
+      this.incomingEdges.set(node, new Set());
     }
   },
   /**
@@ -106,10 +106,7 @@ DepGraph.prototype = {
       this.incomingEdges.delete(node);
       [this.incomingEdges, this.outgoingEdges].forEach(function (edgeList) {
         edgeList.forEach(function (v) {
-          var idx = v.indexOf(node);
-          if (idx >= 0) {
-            v.splice(idx, 1);
-          }
+          v.delete(node);
         });
       });
     }
@@ -151,31 +148,20 @@ DepGraph.prototype = {
     if (!this.hasNode(to)) {
       throw new Error("Node does not exist: " + to);
     }
-    if (this.outgoingEdges.get(from).indexOf(to) === -1) {
-      this.outgoingEdges.get(from).push(to);
-    }
-    if (this.incomingEdges.get(to).indexOf(from) === -1) {
-      this.incomingEdges.get(to).push(from);
-    }
+    this.outgoingEdges.get(from).add(to);
+    this.incomingEdges.get(to).add(from);
     return true;
   },
   /**
    * Remove a dependency between two nodes.
    */
   removeDependency: function (from, to) {
-    var idx;
     if (this.hasNode(from)) {
-      idx = this.outgoingEdges.get(from).indexOf(to);
-      if (idx >= 0) {
-        this.outgoingEdges.get(from).splice(idx, 1);
-      }
+      this.outgoingEdges.get(from).delete(to);
     }
 
     if (this.hasNode(to)) {
-      idx = this.incomingEdges.get(to).indexOf(from);
-      if (idx >= 0) {
-        this.incomingEdges.get(to).splice(idx, 1);
-      }
+      this.incomingEdges.get(to).delete(from);
     }
   },
   /**
@@ -187,8 +173,8 @@ DepGraph.prototype = {
     var result = new DepGraph();
     source.nodes.forEach(function (v, n) {
       result.nodes.set(n, v);
-      result.outgoingEdges.set(n, source.outgoingEdges.get(n).slice(0));
-      result.incomingEdges.set(n, source.incomingEdges.get(n).slice(0));
+      result.outgoingEdges.set(n, new Set(source.outgoingEdges.get(n)));
+      result.incomingEdges.set(n, new Set(source.incomingEdges.get(n)));
     });
     result.circular = source.circular;
     return result;
@@ -200,7 +186,7 @@ DepGraph.prototype = {
    */
   directDependenciesOf: function (node) {
     if (this.hasNode(node)) {
-      return this.outgoingEdges.get(node).slice(0);
+      return [...this.outgoingEdges.get(node)];
     } else {
       throw new Error("Node does not exist: " + node);
     }
@@ -212,7 +198,7 @@ DepGraph.prototype = {
    */
   directDependantsOf: function (node) {
     if (this.hasNode(node)) {
-      return this.incomingEdges.get(node).slice(0);
+      return [...this.incomingEdges.get(node)];
     } else {
       throw new Error("Node does not exist: " + node);
     }
@@ -303,7 +289,7 @@ DepGraph.prototype = {
       // run a DFS starting at these points to get the order
       keys
         .filter(function (node) {
-          return self.incomingEdges.get(node).length === 0;
+          return self.incomingEdges.get(node).size === 0;
         })
         .forEach(function (n) {
           DFS(n);
@@ -331,7 +317,7 @@ DepGraph.prototype = {
   entryNodes: function () {
     var self = this;
     return Array.from(this.nodes.keys()).filter(function (node) {
-      return self.incomingEdges.get(node).length === 0;
+      return self.incomingEdges.get(node).size === 0;
     });
   },
 };

--- a/specs/dep_graph_spec.js
+++ b/specs/dep_graph_spec.js
@@ -541,7 +541,20 @@ describe("DepGraph Performance", function () {
     var start = new Date().getTime();
     g.overallOrder();
     var end = new Date().getTime();
-    expect(start - end).toBeLessThan(1000);
+    expect(end - start).toBeLessThan(1000);
+  });
+
+  it("should construct very large graph with high-degree node in a reasonable amount of time", function () {
+    var start = new Date().getTime();
+    var g = new DepGraph();
+    // Create a graph with 100000 nodes, all depending on the same hub
+    g.addNode("hub");
+    for (var i = 0; i < 100000; i++) {
+      g.addNode(i.toString());
+      g.addDependency(i.toString(), "hub");
+    }
+    var end = new Date().getTime();
+    expect(end - start).toBeLessThan(1000);
   });
 });
 


### PR DESCRIPTION
Hi,

we ran into some performance problems constructing graphs with high-degree nodes, and using Sets instead of Arrays for as Adjacency Lists worked for us.

(We spent almost 100% of the time [on this line](https://github.com/jriecken/dependency-graph/blob/a9eb7aa253b857ec7652dddefb48a350af787ef4/lib/dep_graph.js#L157) while inserting new dependencies because we had high-degree nodes in the graph.)

- It shouldn't hurt anyone since Sets iterate in insertion-order, same as Arrays.
- We're creating a copy of the adjacency list during DFS traversal "to be order-compatible with the old DFS implementation", a suggestion could be to iterate in natural order and bump the major version?